### PR TITLE
mss -> msgs

### DIFF
--- a/jsk.rosinstall
+++ b/jsk.rosinstall
@@ -98,7 +98,7 @@
     uri: https://github.com/ros-naoqi/naoqi_bridge.git
     local-name: ros_naoqi/naoqi_bridge
 - git:
-    uri: https://github.com/ros-naoqi/naoqi_bridge_mss.git
+    uri: https://github.com/ros-naoqi/naoqi_bridge_msgs.git
     local-name: ros_naoqi/naoqi_bridge_msgs
 - git:
     local-name: roboticsgroup/roboticsgroup_gazebo_plugins


### PR DESCRIPTION
fixed typo, but I think it ok to remove all naoqi repository from jsk.rosbuild, we're ok to use deb version
